### PR TITLE
fix: GCS CORS設定の追加とProd環境へのStartup CPU Boost適用

### DIFF
--- a/terraform/modules/gcp_base/main.tf
+++ b/terraform/modules/gcp_base/main.tf
@@ -189,6 +189,13 @@ resource "google_storage_bucket" "uploads" {
     }
   }
 
+  cors {
+    origin          = ["*"]
+    method          = ["GET", "HEAD", "PUT", "POST", "DELETE", "OPTIONS"]
+    response_header = ["*"]
+    max_age_seconds = 3600
+  }
+
   depends_on = [google_project_service.apis]
 }
 
@@ -353,9 +360,10 @@ resource "google_cloud_run_service" "default" {
 
     metadata {
       annotations = {
-        "autoscaling.knative.dev/minScale"  = tostring(var.min_instances)
-        "autoscaling.knative.dev/maxScale"  = tostring(var.max_instances)
-        "run.googleapis.com/cpu-throttling" = "true" # Ensure CPU is only allocated during request processing
+        "autoscaling.knative.dev/minScale"     = tostring(var.min_instances)
+        "autoscaling.knative.dev/maxScale"     = tostring(var.max_instances)
+        "run.googleapis.com/cpu-throttling"    = "true" # Ensure CPU is only allocated during request processing
+        "run.googleapis.com/startup-cpu-boost" = var.startup_cpu_boost ? "true" : "false"
       }
     }
   }

--- a/terraform/modules/gcp_base/variables.tf
+++ b/terraform/modules/gcp_base/variables.tf
@@ -96,3 +96,9 @@ variable "currency_code" {
   type        = string
   default     = "JPY"
 }
+
+variable "startup_cpu_boost" {
+  description = "Enable Cloud Run Startup CPU Boost"
+  type        = bool
+  default     = false
+}

--- a/terraform/prod/gcp/main.tf
+++ b/terraform/prod/gcp/main.tf
@@ -31,6 +31,7 @@ module "gcp_app" {
   billing_account      = var.billing_account
   budget_amount        = 1000 # 1000 JPY
   image_tag            = var.image_tag
+  startup_cpu_boost    = true
 }
 
 module "gh_oidc" {


### PR DESCRIPTION
# Summary
Staging/Prod環境でのファイルアップロード時に発生する「Failed to fetch」エラーの修正と、Production環境のコールドスタート対策としてCloud RunのStartup CPU Boostを有効化しました。
# Type of Change
- [x] Bug fix (不具合の修正)
- [ ] New feature (新機能の追加)
- [x] Infrastructure change (インフラ設定の変更)
- [ ] Refactor (リファクタリング)
# Detailed Changes
## 1. GCS CORS設定の追加 (Bug Fix)
- **Problem**: フロントエンドからGCSへの直接アップロード (PUT) が、CORS設定不足によりブラウザでブロックされ「Failed to fetch」エラーが発生していた。
- **Fix**: [terraform/modules/gcp_base/main.tf](cci:7://file:///h:/github-repo/Thesalo_gallery/terraform/modules/gcp_base/main.tf:0:0-0:0) の `google_storage_bucket` リソースに `cors` ブロックを追加し、全オリジンからのPUT/POST等を許可するように修正。
## 2. Prod環境でのStartup CPU Boost有効化 (Feature)
- **Goal**: Production環境でのコンテナ起動時間（コールドスタート）を短縮し、ユーザー体験を向上させる。
- **Change**:
    - Terraformの共通モジュール (`modules/gcp_base`) に `startup_cpu_boost` 変数を追加。
    - [modules/gcp_base/main.tf](cci:7://file:///h:/github-repo/Thesalo_gallery/terraform/modules/gcp_base/main.tf:0:0-0:0) の Cloud Run サービス定義で、変数が `true` の場合のみ `run.googleapis.com/startup-cpu-boost` アノテーションを付与するよう修正。
    - [terraform/prod/gcp/main.tf](cci:7://file:///h:/github-repo/Thesalo_gallery/terraform/prod/gcp/main.tf:0:0-0:0) でのみ `startup_cpu_boost = true` を指定。
